### PR TITLE
Use latest version for golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # the version of golangci-lint.
-          version: v1.32.2
+          version: latest
 
           # show only new issues if it's a pull request.
           only-new-issues: false


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>